### PR TITLE
Fix Deprecated Github Commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Terraform Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.x.x'
 
@@ -31,17 +31,17 @@ jobs:
       matrix:
         terraform: ['0.14.x', '0.15.x', '1.x.x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets[env.aws_key_name] }}
           aws-secret-access-key: ${{ secrets[env.aws_secret_name] }}
           aws-region: us-west-2
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform }}
 


### PR DESCRIPTION
This is a best attempt pull request to upgrade outdated actions. Failure to upgrade may mean your actions stop working on June 1st, 2023. We only targeted one branch (usually development) and you can deploy those changes to other branches. Some workflows may need extra tweaking to work. Feel free to contact Jamie Visker if you have questions or want another branch targeted.